### PR TITLE
Depend on Terminal::ANSIColor

### DIFF
--- a/META.info
+++ b/META.info
@@ -8,6 +8,6 @@
         "Questhub::Quest::State" : "lib/Questhub/Quest/State.pm6"
     },
     "author" : "Jonathan Scott Duff <duff@pobox.com>",
-    "depends" : [ "JSON::Tiny", "HTTP::UserAgent", "Term::ANSIColor", "IO::Socket::SSL" ],
+    "depends" : [ "JSON::Tiny", "HTTP::UserAgent", "Terminal::ANSIColor", "IO::Socket::SSL" ],
     "source-url" : "git://github.com/perlpilot/p6-Questhub.git"
 }


### PR DESCRIPTION
Term::ANSIColor is replaced by Terminal::ANSIColor, and will be removed from the ecosystem when this gets merged.